### PR TITLE
adding support for rofi

### DIFF
--- a/config
+++ b/config
@@ -65,7 +65,7 @@ bindsym $mod+Shift+q kill
 # start dmenu (a program launcher)
 # bindsym $mod+d exec --no-startup-id dmenu_run
 # A more modern dmenu replacement is rofi:
-bindsym $mod+d exec --no-startup-id "rofi -show drun -theme ~/.config/rofi/launcher.rasi"
+bindsym $mod+d exec --no-startup-id "rofi -show drun -theme ~/.config/rofi/config.rasi"
 # There also is i3-dmenu-desktop which only displays applications shipping a
 # .desktop file. It is a wrapper around dmenu, so you need that installed.
 # bindcode $mod+40 exec --no-startup-id i3-dmenu-desktop
@@ -162,8 +162,8 @@ bindsym $mod+Shift+c reload
 # restart i3 inplace (preserves your layot/session, can be used to upgrade i3)
 bindsym $mod+Shift+r restart
 # exit i3 (logs you out of your X session)
-# bindsym $mod+Shift+e exec "i3-nagbar -t warning -m 'You pressed the exit shortcut. Do you really want to exit i3? This will end your X session.' -B 'Yes, exit i3' 'i3-msg exit'"
-bindsym $mod+Shift+e exec --no-startup-id ~/.config/rofi/powermenu.sh
+bindsym $mod+Shift+e exec "i3-nagbar -t warning -m 'You pressed the exit shortcut. Do you really want to exit i3? This will end your X session.' -B 'Yes, exit i3' 'i3-msg exit'"
+# bindsym $mod+Shift+e exec --no-startup-id ~/.config/rofi/powermenu.sh
 
 # resize window (you can also use the mouse for that)
 mode "resize" {
@@ -200,3 +200,29 @@ bar {
 
 # exec_always --no-startup-id ~/.config/polybar/launch.sh
 
+## Theme Rosepine dawn 
+# set primary Rosé Pine Dawn colorscheme colors
+set $base           #faf4ed
+set $surface        #fffaf3
+set $overlay        #f2e9e1
+set $muted          #9893a5
+set $subtle         #797593
+set $text           #575279
+set $love           #b4637a
+set $gold           #ea9d34
+set $rose           #d7827e
+set $pine           #286983
+set $foam           #56949f
+set $iris           #907aa9
+set $highlightlow   #f4ede8
+set $highlightmed   #dfdad9
+set $highlighthigh  #cecacd
+
+# Teming border and Windows --------------
+# target                 title     bg    text   indicator  border
+client.focused           $rose     $base $text  $rose      $rose
+client.focused_inactive  $text     $base $text  $subtle    $surface
+client.unfocused         $text     $base $text  $overlay   $overlay
+client.urgent            $text     $base $text  $love      $love
+client.placeholder       $base     $base $text  $overlay   $overlay
+client.background        $base


### PR DESCRIPTION
This pull request makes several updates to the i3 window manager configuration file to improve usability and introduce a new theme. The most notable changes involve updating launcher and exit commands, as well as adding a Rosé Pine Dawn colorscheme for theming.

### Command Updates:
* Updated the `bindsym $mod+d` command to use a new theme file for the `rofi` launcher (`~/.config/rofi/config.rasi` instead of `~/.config/rofi/launcher.rasi`).
* Reverted the `bindsym $mod+Shift+e` command to use the default i3 exit confirmation dialog instead of the custom `rofi` power menu script. The custom script is now commented out.

### Theming:
* Added a Rosé Pine Dawn colorscheme to the configuration, defining primary colors and applying them to window borders and client states (e.g., focused, unfocused, urgent).